### PR TITLE
Remove client_id

### DIFF
--- a/domainr/domainr.factor
+++ b/domainr/domainr.factor
@@ -9,7 +9,7 @@ IN: domainr
 : domainr-url ( query -- url )
     URL" https://api.domainr.com/v1/search"
     swap "q" set-query-param
-    "factor_lib" "client_id" set-query-param ;
+    "{your-mashape-key}" "client_id" set-query-param ;
 
 TUPLE: result domain host path subdomain availability
 register_url ;


### PR DESCRIPTION
Due to API abuse, we're locking these down further. Details in our [API documentation](http://domainr.build/docs/authentication).
